### PR TITLE
Added vcsPokeRomByte and vcsSetNextAddress functions to support ELF r…

### DIFF
--- a/hardware/memory/cartridge/elf/memory.go
+++ b/hardware/memory/cartridge/elf/memory.go
@@ -590,6 +590,18 @@ func (mem *elfMemory) decode(ef *elf.File) error {
 						function: vcsJmpToRam3,
 						support:  false,
 					})
+				case "vcsPokeRomByte":
+					tgt, err = mem.relocateStrongArmFunction(strongArmFunctionSpec{
+						name:     sym.Name,
+						function: vcsPokeRomByte,
+						support:  false,
+					})
+				case "vcsSetNextAddress":
+					tgt, err = mem.relocateStrongArmFunction(strongArmFunctionSpec{
+						name:     sym.Name,
+						function: vcsSetNextAddress,
+						support:  true,
+					})
 
 				// C library functions that are often not linked but required
 				case "randint":

--- a/hardware/memory/cartridge/elf/strongarm.go
+++ b/hardware/memory/cartridge/elf/strongarm.go
@@ -717,6 +717,30 @@ func vcsJmpToRam3(mem *elfMemory) {
 	}
 }
 
+// void vcsPokeRomByte(uint16_t uint16_t address, uint8_t data)
+func vcsPokeRomByte(mem *elfMemory) {
+	address := uint16(mem.strongarm.running.registers[0])
+	data := uint8(mem.strongarm.running.registers[1])
+	mem.setNextRomAddress(address)
+
+	switch mem.strongarm.running.state {
+	case 0:
+		if mem.injectRomByte(data) {
+			mem.strongarm.running.state++
+		}
+	case 1:
+		if mem.yieldDataBusToStack() {
+			mem.endStrongArmFunction()
+		}
+	}
+}
+
+// void vcsSetNextAddress(uint16_t address)
+func vcsSetNextAddress(mem *elfMemory) {
+	address := uint16(mem.strongarm.running.registers[0])
+	mem.setNextRomAddress(address)
+}
+
 // sequence for initialisation triggered by the accessing of the cpubus.Reset
 // address. the sequence is very strict so there is no need for coordination
 // with setNextAddress() or injectRomByte()


### PR DESCRIPTION
…oms that transfer control from TIA RAM back to ARM. Primarily used in testing UCA Firmware.