### PR TITLE
added headless screenshot command

### DIFF
--- a/debugger/commands.go
+++ b/debugger/commands.go
@@ -1325,6 +1325,16 @@ func (dbg *Debugger) processTokens(tokens *commandline.Tokens) error {
 			dbg.printLine(terminal.StyleInstrument, dbg.vcs.TV.String())
 		}
 
+	case cmdScreenshot:
+		path, _ := tokens.Get()
+		frameInfo, err := dbg.capture.save(path)
+		if err != nil {
+			return err
+		}
+		size := dbg.capture.completed.Bounds().Size()
+		dbg.printLine(terminal.StyleFeedback, "screenshot: %s (frame=%d, spec=%s, size=%dx%d)",
+			path, frameInfo.FrameNum, frameInfo.Spec.ID, size.X, size.Y)
+
 	// information about the machine (sprites, playfield)
 	case cmdPlayer:
 		plyr := -1

--- a/debugger/commands_help.go
+++ b/debugger/commands_help.go
@@ -220,6 +220,13 @@ selected TV specification. Supplying an argument to the TV SPEC command will set
 specification. AUTO indicates that the specification will change if the condition of the TV signal
 suggest that it should.`,
 
+	cmdScreenshot: `Save the most recently completed TV frame as a PNG image. The image is cropped
+to the active visible area and is written synchronously, so a successful command result means the
+file is ready for inspection.
+
+The command does not capture a partial frame. Run emulation to a frame breakpoint before using
+SCREENSHOT.`,
+
 	cmdPlayer: `Display the current state of the player sprites. The player information to
 display can be selected with 0 or 1 arguments. Omitting this argument will show
 information for both players.

--- a/debugger/commands_template.go
+++ b/debugger/commands_template.go
@@ -89,6 +89,8 @@ const (
 	cmdVersion  = "VERSION"
 )
 
+const cmdScreenshot = "SCREENSHOT"
+
 var commandTemplate = []string{
 	cmdReload,
 	cmdReset,
@@ -124,6 +126,7 @@ var commandTemplate = []string{
 	cmdRIOT + " (PORTS|TIMER)",
 	cmdAudio,
 	cmdTV + fmt.Sprintf(" (FRAME|VSYNC|SPEC (%s))", strings.Join(specification.ReqSpecList, "|")),
+	cmdScreenshot + " %<file>F",
 	cmdPlayer + " (0|1)",
 	cmdMissile + " (0|1)",
 	cmdBall,

--- a/debugger/debugger.go
+++ b/debugger/debugger.go
@@ -92,6 +92,9 @@ type Debugger struct {
 	// components may change (during rewind for example)
 	vcs *hardware.VCS
 
+	// software TV renderer used to save completed frames without a GUI
+	capture *frameCapture
+
 	// keep a reference to the current cartridgeloader to make sure Close() is called
 	cartload *cartridgeloader.Loader
 
@@ -345,6 +348,8 @@ func NewDebugger(opts CommandLineOptions, create CreateUserInterface) (*Debugger
 	if err != nil {
 		return nil, fmt.Errorf("debugger: %w", err)
 	}
+	dbg.capture = newFrameCapture(dbg.vcs.TV)
+	dbg.vcs.TV.AddPixelRenderer(dbg.capture)
 
 	// create userinput/controllers handler
 	dbg.controllers = userinput.NewControllers(dbg.vcs.Input)

--- a/debugger/frame_capture.go
+++ b/debugger/frame_capture.go
@@ -1,0 +1,134 @@
+// This file is part of Gopher2600.
+//
+// Gopher2600 is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Gopher2600 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Gopher2600.  If not, see <https://www.gnu.org/licenses/>.
+
+package debugger
+
+import (
+	"fmt"
+	"image"
+	"image/color"
+	"image/draw"
+	"image/png"
+	"os"
+	"path/filepath"
+
+	"github.com/jetsetilly/gopher2600/hardware/television"
+	"github.com/jetsetilly/gopher2600/hardware/television/frameinfo"
+	"github.com/jetsetilly/gopher2600/hardware/television/signal"
+	"github.com/jetsetilly/gopher2600/hardware/television/specification"
+)
+
+// frameCapture keeps an immutable copy of the last completed TV frame. Keeping
+// a separate working image prevents a screenshot taken at a breakpoint from
+// containing pixels from the next, incomplete frame.
+type frameCapture struct {
+	tv        *television.Television
+	working   *image.RGBA
+	completed *image.RGBA
+	frameInfo frameinfo.Current
+}
+
+func newFrameCapture(tv *television.Television) *frameCapture {
+	capture := &frameCapture{
+		tv:        tv,
+		working:   image.NewRGBA(image.Rect(0, 0, specification.ClksScanline, specification.AbsoluteMaxScanlines)),
+		frameInfo: frameinfo.NewCurrent(specification.SpecNTSC),
+	}
+	if tv != nil {
+		capture.frameInfo = tv.GetFrameInfo()
+	}
+	capture.Reset()
+	return capture
+}
+
+func (capture *frameCapture) NewFrame(frameInfo frameinfo.Current) error {
+	crop := frameInfo.Crop().Intersect(capture.working.Bounds())
+	if crop.Empty() {
+		return fmt.Errorf("screenshot: invalid frame bounds %s", crop)
+	}
+
+	completed := image.NewRGBA(image.Rect(0, 0, crop.Dx(), crop.Dy()))
+	draw.Draw(completed, completed.Bounds(), capture.working, crop.Min, draw.Src)
+
+	capture.completed = completed
+	capture.frameInfo = frameInfo
+	return nil
+}
+
+func (capture *frameCapture) NewScanline(int) error {
+	return nil
+}
+
+func (capture *frameCapture) SetPixels(sig []signal.SignalAttributes, last int) error {
+	if capture.tv != nil {
+		capture.frameInfo = capture.tv.GetFrameInfo()
+	}
+
+	limit := min(last+1, len(sig), len(capture.working.Pix)/4)
+	for i := 0; i < len(capture.working.Pix)/4; i++ {
+		col := color.RGBA{A: 255}
+		if i < limit && !sig[i].VBlank && sig[i].Index != signal.NoSignal {
+			col = capture.frameInfo.Spec.GetColorScreen(sig, i, specification.ClksScanline)
+			col.A = 255
+		}
+
+		offset := i * 4
+		capture.working.Pix[offset] = col.R
+		capture.working.Pix[offset+1] = col.G
+		capture.working.Pix[offset+2] = col.B
+		capture.working.Pix[offset+3] = col.A
+	}
+	return nil
+}
+
+func (capture *frameCapture) Reset() {
+	for i := 0; i < len(capture.working.Pix); i += 4 {
+		capture.working.Pix[i] = 0
+		capture.working.Pix[i+1] = 0
+		capture.working.Pix[i+2] = 0
+		capture.working.Pix[i+3] = 255
+	}
+	capture.completed = nil
+}
+
+func (capture *frameCapture) EndRendering() error {
+	return nil
+}
+
+func (capture *frameCapture) save(path string) (frameinfo.Current, error) {
+	if capture.completed == nil {
+		return frameinfo.Current{}, fmt.Errorf("screenshot: no completed frame available")
+	}
+
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".gopher2600-screenshot-*.png")
+	if err != nil {
+		return frameinfo.Current{}, fmt.Errorf("screenshot: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+
+	if err := png.Encode(temporary, capture.completed); err != nil {
+		_ = temporary.Close()
+		return frameinfo.Current{}, fmt.Errorf("screenshot: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return frameinfo.Current{}, fmt.Errorf("screenshot: %w", err)
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return frameinfo.Current{}, fmt.Errorf("screenshot: %w", err)
+	}
+
+	return capture.frameInfo, nil
+}

--- a/debugger/frame_capture_test.go
+++ b/debugger/frame_capture_test.go
@@ -1,0 +1,100 @@
+// This file is part of Gopher2600.
+//
+// Gopher2600 is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Gopher2600 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Gopher2600.  If not, see <https://www.gnu.org/licenses/>.
+
+package debugger
+
+import (
+	"image/png"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jetsetilly/gopher2600/hardware/television/frameinfo"
+	"github.com/jetsetilly/gopher2600/hardware/television/signal"
+	"github.com/jetsetilly/gopher2600/hardware/television/specification"
+)
+
+func TestFrameCaptureSave(t *testing.T) {
+	capture := newFrameCapture(nil)
+	signals := make([]signal.SignalAttributes, specification.AbsoluteMaxClks)
+	for i := range signals {
+		signals[i] = signal.SignalAttributes{Index: signal.NoSignal, Color: signal.ZeroBlack}
+	}
+
+	pixel := specification.ClksHBlank
+	signals[pixel] = signal.SignalAttributes{Index: pixel, Color: 0x46}
+	if err := capture.SetPixels(signals, len(signals)-1); err != nil {
+		t.Fatal(err)
+	}
+
+	frameInfo := frameinfo.NewCurrent(specification.SpecNTSC)
+	frameInfo.FrameNum = 42
+	frameInfo.VisibleTop = 0
+	frameInfo.VisibleBottom = 0
+	if err := capture.NewFrame(frameInfo); err != nil {
+		t.Fatal(err)
+	}
+	want := frameInfo.Spec.GetColorScreen(signals, pixel, specification.ClksScanline)
+
+	// Mutating the working frame must not change the completed image.
+	signals[pixel].VBlank = true
+	if err := capture.SetPixels(signals, len(signals)-1); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(t.TempDir(), "frame.png")
+	savedInfo, err := capture.save(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if savedInfo.FrameNum != frameInfo.FrameNum {
+		t.Fatalf("frame number = %d, want %d", savedInfo.FrameNum, frameInfo.FrameNum)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	img, err := png.Decode(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := img.Bounds().Size().X, specification.ClksVisible; got != want {
+		t.Fatalf("image width = %d, want %d", got, want)
+	}
+	if got, want := img.Bounds().Size().Y, 1; got != want {
+		t.Fatalf("image height = %d, want %d", got, want)
+	}
+
+	got := img.At(0, 0)
+	if got != want {
+		t.Fatalf("pixel = %v, want %v", got, want)
+	}
+}
+
+func TestFrameCaptureSaveBeforeFrame(t *testing.T) {
+	capture := newFrameCapture(nil)
+	_, err := capture.save(filepath.Join(t.TempDir(), "frame.png"))
+	if err == nil {
+		t.Fatal("expected error before first completed frame")
+	}
+}
+
+func TestScreenshotCommandTemplate(t *testing.T) {
+	if err := debuggerCommands.Validate("SCREENSHOT frame.png"); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- add a synchronous SCREENSHOT debugger command that writes the most recently completed TV frame as a PNG
- attach a software pixel renderer so capture works without SDL/OpenGL in HEADLESS mode
- cover PNG output, completed-frame isolation, and pre-frame errors

## Testing
- go test ./...
- go vet ./...
- go build -o gopher2600 .
- ran ./gopher2600 HEADLESS against up-1-way.a26 through frame 60; produced a valid 160x214 NTSC PNG